### PR TITLE
Fix BoundsError on empty pulses in paired_representation

### DIFF
--- a/src/UtilsData.jl
+++ b/src/UtilsData.jl
@@ -960,15 +960,29 @@ function paired_representation(start_time,n_pre,delay_pre,n_pos,delay_pos,delay,
 		append!(post_pulses,ifelse(causal==false,0,delay) .+ i .+ range(0., length=n_pos, stop=delay_pos*ifelse(n_pos>1,n_pos-1,n_pos)))
 	end
 	if repeat_times>0 && repetion>0
-		pre_pulses_aux = pre_pulses .-start_time
+		if !isempty(pre_pulses)
+            pre_pulses_aux = pre_pulses .- start_time
+            for i in 2:repeat_times
+                append!(pre_pulses, pre_pulses_aux .+ repeat_after .+ pre_pulses[end])
+            end
+        end
+        if !isempty(post_pulses)
+            post_pulses_aux = post_pulses .- start_time
+            for i in 2:repeat_times
+                append!(post_pulses, post_pulses_aux .+ repeat_after .+ post_pulses[end])
+            end
+        end
+
+		#= pre_pulses_aux = pre_pulses .-start_time
 		for i in 2:repeat_times
 			append!(pre_pulses,pre_pulses_aux .+ repeat_after .+ pre_pulses[end])
 		end
 		post_pulses_aux = post_pulses .-start_time
 		for i in 2:repeat_times
 			append!(post_pulses,post_pulses_aux .+ repeat_after .+ post_pulses[end])
-		end
-	end
+		end =#
+		
+	end 
 	return pre_pulses, post_pulses
 end
 

--- a/src/UtilsData.jl
+++ b/src/UtilsData.jl
@@ -972,16 +972,6 @@ function paired_representation(start_time,n_pre,delay_pre,n_pos,delay_pos,delay,
                 append!(post_pulses, post_pulses_aux .+ repeat_after .+ post_pulses[end])
             end
         end
-
-		#= pre_pulses_aux = pre_pulses .-start_time
-		for i in 2:repeat_times
-			append!(pre_pulses,pre_pulses_aux .+ repeat_after .+ pre_pulses[end])
-		end
-		post_pulses_aux = post_pulses .-start_time
-		for i in 2:repeat_times
-			append!(post_pulses,post_pulses_aux .+ repeat_after .+ post_pulses[end])
-		end =#
-		
 	end 
 	return pre_pulses, post_pulses
 end


### PR DESCRIPTION
This PR fixes a `BoundsError` that was identified during an automated scan of the protocol database.
## The issue: 
When processing certain protocols that do not contain any pre-synaptic or post-synaptic pulses (such as the `oconnor` and `Cao-TBS` protocols), the paired_representation function crashes. The error occurs because the loop tries to access the last element of an empty array (`pre_pulses[end]` or `post_pulses[end]`) to calculate the timing of repeated epochs.
## The fix: 
Added if `!isempty(pre_pulses)` and if `!isempty(post_pulses)` conditional checks around the repetition loops in `src/UtilsData.jl`. This safely protects the array access and prevents the crash for protocols with empty pulse lists, while keeping the logic intact for standard protocols.