### PR TITLE
Fix DimensionMismatch in Mizuno01-LTP-Mg

### DIFF
--- a/src/UtilsData.jl
+++ b/src/UtilsData.jl
@@ -895,9 +895,6 @@ function dataProtocol(paper)
 		if paper == "Mizuno01-LTP-Mg"
 			for Mg in [.0001]#; collect(.1:.1:1.);collect(1.2: .2:2.0)]
 				for pulses in [1; 3; 5; 10; 25; 50; 100; 150]
-						# missing one arg : 
-						#push!(data_protocol,[1 0. 0 0.  0.     pulses  1.    true     "LTP_$(pulses)_$(Mg)"	 -0.5 "LTD" "$paper" 26. 3e3 2.4e3 Mg 0 0. 2. 12 "yes" "no" 0. 0. 200. 0. 0.])
-						# better : 
 						push!(data_protocol,[1 0. 0 0.  0.     pulses  1.    true     "LTP_$(pulses)_$(Mg)"	 -0.5 "LTD" "$paper" 26. 3e3 2.4e3 Mg 0 0. 0. 2. 12 "yes" "no" 0. 0. 200. 0. 0.])
 				end
 			end

--- a/src/UtilsData.jl
+++ b/src/UtilsData.jl
@@ -895,9 +895,10 @@ function dataProtocol(paper)
 		if paper == "Mizuno01-LTP-Mg"
 			for Mg in [.0001]#; collect(.1:.1:1.);collect(1.2: .2:2.0)]
 				for pulses in [1; 3; 5; 10; 25; 50; 100; 150]
-						# missing one arg
-						push!(data_protocol,[1 0. 0 0.  0.     pulses  1.    true     "LTP_$(pulses)_$(Mg)"	 -0.5 "LTD" "$paper" 26. 3e3 2.4e3 Mg 0 0. 2. 12 "yes" "no" 0. 0. 200. 0. 0.])
-# suggestion #			push!(data_protocol,[1 0. 0 0.  0.     pulses  1.    true     "LTP_$(pulses)_$(Mg)"	 -0.5 "LTD" "$paper" 26. 3e3 2.4e3 Mg 0 0. 0. 2. 12 "yes" "no" 0. 0. 200. 0. 0.])
+						# missing one arg : 
+						#push!(data_protocol,[1 0. 0 0.  0.     pulses  1.    true     "LTP_$(pulses)_$(Mg)"	 -0.5 "LTD" "$paper" 26. 3e3 2.4e3 Mg 0 0. 2. 12 "yes" "no" 0. 0. 200. 0. 0.])
+						# better : 
+						push!(data_protocol,[1 0. 0 0.  0.     pulses  1.    true     "LTP_$(pulses)_$(Mg)"	 -0.5 "LTD" "$paper" 26. 3e3 2.4e3 Mg 0 0. 0. 2. 12 "yes" "no" 0. 0. 200. 0. 0.])
 				end
 			end
 		end


### PR DESCRIPTION
## Description:
This PR fixes a `DimensionMismatch` error identified during the automated scan of the protocol database.
## The issue: 
The `Mizuno01-LTP-Mg` protocol was pushing an array of 27 elements instead of the required 28 elements to the data_protocol table.
## The fix: 
Added a missing `0.` parameter right after the `Mg  0  0.` sequence in `src/UtilsData.jl`. This successfully aligns the protocol parameters with the standard 28-column structure used by the other Mizuno protocols.